### PR TITLE
fix: fix order price calculation

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -12,7 +12,7 @@ class OrderController(BaseController):
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list):
-        price = sum(ingredient.price for ingredient in ingredients)
+        price = sum(ingredient.price for ingredient in ingredients) + size_price
         return round(price, 2)
 
     @classmethod


### PR DESCRIPTION
#### 🤔 Why?

Currently, the backend is not storing the correct total price for the order and the test fails.

#### 🛠 What I changed:

- app/controllers/order.py: I added the size price in the calculate_order_price function. 


#### 🗃️ Issues:

https://trello.com/c/zmciMCgW/9-fix-order-price-calculation-bonus

#### 🚦 Functional Testing Results:

![image](https://github.com/ioet/python-pizza-planet/assets/129772097/a6bfc1a7-c76a-4149-9382-a8a54add1712)
