### PR TITLE
feat: PlZ-9 add word merge to commit prefix

### DIFF
--- a/.github/hooks/commit_msg.py
+++ b/.github/hooks/commit_msg.py
@@ -6,7 +6,7 @@ import sys
 def main():
     with open(sys.argv[1], "r", encoding="utf-8") as f_p:
 
-        commit_prefix = ('fix:', 'feat:', 'refactor:', 'test:')
+        commit_prefix = ('fix:', 'feat:', 'refactor:', 'test:', 'merge:')
 
         lines = f_p.readlines()
 


### PR DESCRIPTION
#### 🤔 Why?

Add the word "merge" to the commit prefixes

#### 🛠 What I changed:

Just added that word in order to be able to commit merge changes

#### 🗃️ Trello Issues:

https://trello.com/c/CmaV7bJw/2-plz9-create-hooks-for-git-commands

